### PR TITLE
Adds StartupWMClass to the flatpak desktop file

### DIFF
--- a/com.github.zadam.trilium.desktop
+++ b/com.github.zadam.trilium.desktop
@@ -6,3 +6,4 @@ Icon=com.github.zadam.trilium
 Exec=trilium
 Categories=Office
 Terminal=false
+StartupWMClass=TriliumNext Notes


### PR DESCRIPTION
This PR adds StartupWMClass to the flatpak desktop file. This allows launchers and docks to associate opened windows with the respective app launcher

### Please confirm your submission meets all the criteria

- [X] I have read the [App Requirements][reqs] and [App Maintenance][maint] pages.
- [X] My pull request follows the instructions at [App Submission][submission].
- [X] I am using only the minimal set of permissions. *(If not, please explain each non-standard permission.)*
- [X] All assets referenced in the manifest are redistributable by any party.  If not, the unredistributable parts are using an extra-data source type.
- [X] I am an upstream contributor to the project. If not, I contacted upstream developers about submitting their software to Flathub. **Link:**
- [X] I own the domain used in the application ID or the domain has a policy for delegating subdomains (e.g. GitHub, SourceForge).
- [X] Any additional patches or files have been submitted to the upstream projects concerned. *(If not, explain why.)*

[reqs]: https://github.com/flathub/flathub/wiki/App-Requirements
[maint]: https://github.com/flathub/flathub/wiki/App-Maintenance
[submission]: https://github.com/flathub/flathub/wiki/App-Submission


